### PR TITLE
adds free(qh); in delaunay_free(qhT *qh) to eliminate memory leak

### DIFF
--- a/deps/MiniQhullWrapper/src/lib/qhullwrapper.c
+++ b/deps/MiniQhullWrapper/src/lib/qhullwrapper.c
@@ -87,6 +87,7 @@ int delaunay_free(qhT *qh)
   /* Free memory from qhull and check that no memory is leaked */
   qh_freeqhull (qh, ! qh_ALL);
   qh_memfreeshort (qh, &curlong, &totlong);
+  free(qh);
   if (curlong || totlong) return -2;
 
   return 0;


### PR DESCRIPTION
## Problem 

I noticed a lot of allocated memory when computing many delaunay tessellations, which only de-allocates when
Julia terminates, like so

```julia
using MiniQhull
using ProgressMeter
x = randn(199,2)
@showprogress for i in 1:10^5
	tess = delaunay(permutedims(x,(2,1)))
	tess = nothing
end # ~40 seconds
# ~1 GB is not de-allocated until Julia terminates
```
This is a lot of ```delaunay``` calls! But my applications do need this sort of magnitude.

## Details

I saw that ```_delaunay``` creates a new qhull handler by calling the C, but the call
to ```delaunay_free``` does not release it, and it is not free'd anywhere else

```julia
function _delaunay(dim::Int32,numpoints::Int32,points::Array{Float64}) 
    ...
    qh = new_qhull_handler() # qh pointer created in C
    ...
    ierror = delaunay_free(qh) # does not destroy qh pointer!
    ... # other code does not destroy it either
end
```
e.g in julia 1.4: ![leak](https://user-images.githubusercontent.com/33522054/92260345-a90c0680-eecf-11ea-8de9-8d730606f6e5.png)

## Fix

The minimal solution in this PR is to add ```free(qh)``` in deps/MiniQhullWrapper/src/lib/qhullwrapper.c Line 90 like so

```julia
int delaunay_free(qhT *qh)
{

  int curlong, totlong;

  /* Free memory from qhull and check that no memory is leaked */
  qh_freeqhull (qh, ! qh_ALL);
  qh_memfreeshort (qh, &curlong, &totlong);
  free(qh);
  if (curlong || totlong) return -2;

  return 0;
}
```

This works on my machine and the [Travis test passes](https://travis-ci.com/github/harveydevereux/MiniQhull.jl/builds/182791924).

Perhaps a better fix is a ```free_qh_handler(qh)``` function which calls a C function to destroy the pointer