### PR TITLE
Less strict type requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Tests, Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1' 
+          - '1.0'
+          - '1.3'
+        os:
+          - [ubuntu-latest]
+        arch:
+          - x64
+    steps:
+      # Cancel ongoing CI test runs if pushing to branch again before the previous tests 
+      # have finished
+      - name: Cancel ongoing test runs for previous commits
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
+      # Do tests
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [targets]
-test = ["Test"]
+test = ["Test", "StaticArrays"]

--- a/README.md
+++ b/README.md
@@ -7,26 +7,40 @@
 
 ## Documentation
 
-The `MiniQhull` julia package provides a single function `delaunay` overloaded with 2 methods:
+The `MiniQhull` julia package provides a single function `delaunay` overloaded with 3 methods:
 
 ```julia
 delaunay(dim::Integer, numpoints::Integer, points::AbstractVector) -> Matrix{Int32}
 ```
+
 Compute the Delaunay triangulation of a cloud of points in an arbitrary dimension `dim`. The length of vector `points` must be `dim*numpoints`. Vector `points` holds data in "component major order", i.e., components are consequitive within the vector. The returned matrix has shape `(dim+1, nsimplices)`, where `nsimplices` is the number of
 simplices in the computed Delaunay triangulation.
 
 ```julia
-delaunay(points::Matrix) -> Matrix{Int32}
+delaunay(points::AbstractMatrix) -> Matrix{Int32}
 ```
+
 In this variant, the cloud of points is specified by a matrix with `size(matrix) == (dim, numpoints)`.
+
+```julia
+delaunay(points::AbstractVector) -> Matrix{Int32}
+```
+
+In this variant, the cloud of points is specified with a vector of `dim`-element vectors or
+tuples. It is also possible to use a vector of other tuple-like types, like `SVector` from 
+[StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl).
+
+### Adjusting Qhull flags
 
 You can override the default set of flags that Qhull uses by passing
 an additional `flags` argument:
 
 ```julia
 delaunay(dim::Integer, numpoints::Integer, points::AbstractVector, flags::AbstractString) -> Matrix{Int32}
-delaunay(points::Matrix, flags::AbstractString) -> Matrix{Int32}
+delaunay(points::AbstractMatrix, flags::AbstractString) -> Matrix{Int32}
+delaunay(points::AbstractVector, flags::AbstractString) -> Matrix{Int32}
 ```
+
 The default set of flags is `qhull d Qt Qbb Qc Qz` for up to 3 dimensions, and `qhull d Qt Qbb Qc Qx` for higher dimensions. The flags you pass override the default flags, i.e. you have to pass all the flags that Qhull should use.
 
 ## Examples
@@ -55,19 +69,13 @@ connectivity = delaunay(coordinates)
  1  1
 ```
 
-### Vectors of SVector
-
-You may want to use a `Vector{SVector}`, where `SVector` is from
-[StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl), to represent your
-points. If so, you can use `reinterpret` to represent the points in component major order.
-
 ```julia
 using MiniQhull, StaticArrays
 dim = 5
-npts = 100
+npts = 500
 pts = [SVector{dim, Float64}(rand(dim)) for i = 1:npts];
 flags = "qhull d Qbb Qc QJ Pp" # custom flags
-connectivity = delaunay(dim, npts, reinterpret(Float64, pts), flags)
+connectivity = delaunay(pts, flags)
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ connectivity = delaunay(coordinates)
  1  1
 ```
 
+### Vectors of SVector
+
+You may want to use a `Vector{SVector}`, where `SVector` is from
+[StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl), to represent your
+points. If so, you can use `reinterpret` to represent the points in component major order.
+
+```julia
+using MiniQhull, StaticArrays
+dim = 5
+npts = 100
+pts = [SVector{dim, Float64}(rand(dim)) for i = 1:npts];
+flags = "qhull d Qbb Qc QJ Pp" # custom flags
+connectivity = delaunay(dim, npts, reinterpret(Float64, pts), flags)
+```
+
 ## Installation
 
 `MiniQhull` is a registered Julia package. If your system fulfills all the requirements (see below), `MiniQhull` can be installed using the command:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 The `MiniQhull` julia package provides a single function `delaunay` overloaded with 2 methods:
 
 ```julia
-delaunay(dim::Integer, numpoints::Integer, points::Vector) -> Matrix{Int32}
+delaunay(dim::Integer, numpoints::Integer, points::AbstractVector) -> Matrix{Int32}
 ```
 Compute the Delaunay triangulation of a cloud of points in an arbitrary dimension `dim`. The length of vector `points` must be `dim*numpoints`. Vector `points` holds data in "component major order", i.e., components are consequitive within the vector. The returned matrix has shape `(dim+1, nsimplices)`, where `nsimplices` is the number of
 simplices in the computed Delaunay triangulation.
@@ -24,12 +24,10 @@ You can override the default set of flags that Qhull uses by passing
 an additional `flags` argument:
 
 ```julia
-delaunay(dim::Integer, numpoints::Integer, points::Vector, flags::AbstractString) -> Matrix{Int32}
+delaunay(dim::Integer, numpoints::Integer, points::AbstractVector, flags::AbstractString) -> Matrix{Int32}
 delaunay(points::Matrix, flags::AbstractString) -> Matrix{Int32}
 ```
 The default set of flags is `qhull d Qt Qbb Qc Qz` for up to 3 dimensions, and `qhull d Qt Qbb Qc Qx` for higher dimensions. The flags you pass override the default flags, i.e. you have to pass all the flags that Qhull should use.
-
-
 
 ## Examples
 

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -24,7 +24,7 @@ end
 
 function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
     @assert numpoints*dim == length(points)
-    _delaunay(Int32(dim), Int32(numpoints), points, flags)
+    _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
 end
 
 function delaunay(points::Matrix,

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -7,7 +7,7 @@ export delaunay
 include("load.jl")
 include("bindings.jl")
 
-function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T<:Real
+function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{Float64}, flags::Union{Nothing,AbstractString})
     numcells = Ref{Int32}()
     qh = new_qhull_handler()
     qh == C_NULL && error("Qhull handler is null")
@@ -22,7 +22,7 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags
     cells
 end
 
-function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{Float64}, flags::Union{Nothing,AbstractString}=nothing) 
     @assert numpoints*dim == length(points)
     _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
 end

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -22,6 +22,93 @@ function _delaunay(dim::Int32, numpoints::Int32, points, flags::Union{Nothing,Ab
     cells
 end
 
+"""
+    delaunay(dim::Integer, numpoints::Integer, points::AbstractVector, 
+        [flags::AbstractString]) → Matrix{Int32}
+
+Compute the Delaunay triangulation of a cloud of points in an arbitrary dimension `dim`.
+The vector `points` holds the data in "component major order", i.e., components are 
+consecutive within the vector. The vector `points` therefore must have length 
+`dim * numpoints`.
+
+The returned matrix has shape `(dim + 1, nsimplices)`, where `nsimplices` is the number of 
+simplices in the computed Delaunay triangulation.
+
+You can override the default set of flags that Qhull uses by passing an additional
+positional `flags` argument. The default set of flags is `qhull d Qt Qbb Qc Qz` for up to 
+3 dimensions, and `qhull d Qt Qbb Qc Qx` for higher dimensions. The flags you pass override 
+the default flags, i.e. you have to pass all the flags that Qhull should use.
+
+## Example: passing a column-major ordered vector of points
+
+In this case, the dimension and number of points must be specified.
+
+```julia
+using MiniQhull
+dim          = 2
+numpoints    = 4
+coordinates  = [0,0,0,1,1,0,1,1]
+connectivity = delaunay(dim, numpoints, coordinates)
+# output
+3×2 Array{Int32,2}:
+ 4  4
+ 2  3
+ 1  1
+```
+
+    delaunay(points::AbstractMatrix, [flags::AbstractString]) -> Matrix{Int32}
+
+In this variant, the cloud of points is specified by a matrix with 
+`size(matrix) == (dim, numpoints)`.
+
+## Example: passing a matrix of points
+
+```julia
+using MiniQhull
+coordinates  = [0 0 1 1; 0 1 0 1]
+connectivity = delaunay(coordinates)
+# output
+3×2 Array{Int32,2}:
+ 4  4
+ 2  3
+ 1  1
+```
+
+    delaunay(points::AbstractVector{T}, [flags::AbstractString]) where T -> Matrix{Int32}
+
+In this variant, the cloud of points is specified by a vector of points. 
+
+`points` can a `Vector{Vector}` but this is slow, because the data needs to be flattened 
+and collected before passing the data to Qhull.
+
+```julia
+pts = [[0.,0.], [0.,1.], [1.,0.], [1.,1.]]
+delaunay(pts)
+# output
+3×2 Array{Int32,2}:
+ 4  4
+ 2  3
+ 1  1
+```
+
+A more efficient alternative is of `points` has the same memory layout as a column-major 
+vector, that is, if `T` is some type such that `reinterpret(Float64, points)` yields
+a column-major vector of the points. This avoids extra memory allocations, and is useful 
+if you have a large number of points to triangulate. Examples are using equal-length tuples 
+or `SVector`s to represent the points.
+
+```julia
+using MiniQhull, StaticArrays
+dim = 3
+npts = 500
+pts = [SVector{dim, Float64}(rand(dim)) for i = 1:npts];
+flags = "qhull d Qbb Qc QJ Pp" # some custom flags
+connectivity = delaunay(pts, flags)
+```
+
+"""
+function delaunay end 
+
 function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
     @assert numpoints*dim == length(points)
     _delaunay(Int32(dim), Int32(numpoints), float.(points), flags)

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -22,7 +22,7 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{Float64},
     cells
 end
 
-function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T <: Int
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
     @assert numpoints*dim == length(points)
     _delaunay(Int32(dim), Int32(numpoints), float.(points), flags)
 end

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -22,10 +22,18 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{Float64},
     cells
 end
 
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T <: Int
+    @assert numpoints*dim == length(points)
+    _delaunay(Int32(dim), Int32(numpoints), float.(points), flags)
+end
+
+# If input data are already Float64, then no conversion is needed
 function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{Float64}, flags::Union{Nothing,AbstractString}=nothing) 
     @assert numpoints*dim == length(points)
-    _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
+    _delaunay(Int32(dim), Int32(numpoints), points, flags)
 end
+
+
 
 function delaunay(points::Matrix,
     flags::Union{Nothing,AbstractString}=nothing)

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -7,7 +7,7 @@ export delaunay
 include("load.jl")
 include("bindings.jl")
 
-function _delaunay(dim::Int32, numpoints::Int32, points::Array{Float64}, flags::Union{Nothing,AbstractString}) 
+function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T
     numcells = Ref{Int32}()
     qh = new_qhull_handler()
     qh == C_NULL && error("Qhull handler is null")
@@ -22,8 +22,7 @@ function _delaunay(dim::Int32, numpoints::Int32, points::Array{Float64}, flags::
     cells
 end
 
-function delaunay(dim::Integer, numpoints::Integer, points::Vector,
-                  flags::Union{Nothing,AbstractString}=nothing)
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
     @assert numpoints*dim == size(points,1)
     _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
 end

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -7,7 +7,7 @@ export delaunay
 include("load.jl")
 include("bindings.jl")
 
-function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T
+function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T<:Real
     numcells = Ref{Int32}()
     qh = new_qhull_handler()
     qh == C_NULL && error("Qhull handler is null")
@@ -23,8 +23,8 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags
 end
 
 function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
-    @assert numpoints*dim == size(points,1)
-    _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
+    @assert numpoints*dim == length(points)
+    _delaunay(Int32(dim), Int32(numpoints), points, flags)
 end
 
 function delaunay(points::Matrix,

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -6,7 +6,7 @@ function new_qhull_handler()
 end
 
 # int delaunay_init_and_compute( int dim, int numpoints, coordT *points, int* numcells);
-function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::Array{Float64}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString})
+function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::AbstractArray{T}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString}) where T
     @check_if_loaded
     ccall(delaunay_init_and_compute_c[], 
         Cint, (

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -6,7 +6,7 @@ function new_qhull_handler()
 end
 
 # int delaunay_init_and_compute( int dim, int numpoints, coordT *points, int* numcells);
-function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::AbstractArray{Float64}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString})
+function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString})
     @check_if_loaded
     ccall(delaunay_init_and_compute_c[], 
         Cint, (

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -6,7 +6,7 @@ function new_qhull_handler()
 end
 
 # int delaunay_init_and_compute( int dim, int numpoints, coordT *points, int* numcells);
-function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::AbstractArray{T}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString}) where T
+function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::AbstractArray{Float64}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString})
     @check_if_loaded
     ccall(delaunay_init_and_compute_c[], 
         Cint, (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,36 @@
 using MiniQhull
 using Test
+using StaticArrays
 
 if MiniQhull.QHULL_WRAPPER_LOADED[]
     @testset "MiniQhull" begin
         @test delaunay(2,4,[0,0,0,1,1,0,1,1]) == delaunay([0 0 1 1; 0 1 0 1])
     end
+
+    @testset "Custom array-type" begin 
+        pts = [[0.,0.], [0.,1.], [1.,0.], [1.,1.]]
+        dim = 2
+        x = reinterpret(Float64, [SVector{dim, Float64}(pt) for pt in pts])
+        @test delaunay(dim, length(pts), x) ==  [4 4; 2 3; 1 1]
+    end
+
+    @testset "Vector of vectors" begin
+        pts = [[0.,0.], [0.,1.], [1.,0.], [1.,1.]]
+
+        @testset "Vector of regular vectors" begin 
+            @test delaunay(pts) == [4 4; 2 3; 1 1]
+        end
+
+        @testset "Vector of tuples" begin 
+            tups = [(0.,0.,), (0.,1.,), (1.,0.,), (1.,1., )]
+            @test delaunay(tups) == [4 4; 2 3; 1 1]
+        end
+      
+        @testset "Vector of SVectors" begin
+            @test delaunay([SVector{2, Float64}(pt) for pt in pts]) == [4 4; 2 3; 1 1]
+        end
+    end
+
     @testset "MiniQhull with flags" begin
         c0 = delaunay([0 0 1 1; 0 1 0 1])
         c1 = delaunay([0 0 1 1; 0 1 0 1], nothing)
@@ -17,4 +43,5 @@ if MiniQhull.QHULL_WRAPPER_LOADED[]
         c4 = delaunay([0 0 1 1; 0 1 0 1], GenericString("qhull d Qt Qbb Qc Qz"))
         @test c4 == c0
     end
+
 end


### PR DESCRIPTION
## Problem 

When working with points in (low-ish) N-dimensional space, it is typical in Julia to represent these points by statically sized vectors using the `SVector` type from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl). To pass these points on to `MiniQhull.delaunay`, I first have to gather the points, then convert them to a vector with column-major ordering, which is very slow.

```julia
using MiniQhull, StaticArrays
dim = 5
npts = 300
pts = [SVector{dim, Float64}(rand(dim) for i = 1:npts]

# Works, but is veery slow and allocates a lot of memory
x = Array(vcat(pts...,))
delaunay(dim, npts, x)
```

However, it is possible to `reinterpret` the points as a column-major vector with almost zero extra cost. But currently, using reinterpreted data doesn't work with `MiniQhull.delaunay` because it is hard-coded that the input points must be a `Vector{Float64}`. 

```julia
using MiniQhull, StaticArrays
dim = 5
npts = 300
pts = [SVector{dim, Float64}(rand(dim) for i = 1:npts]

# This operation is fast/allocates almost nothing
x = reinterpret(Float64, pts) #`x` is now of type `Base.ReinterpretArray`

# Fails, because the input must be `Vector{Float64}`
delaunay(dim, npts, x)

# Works, but adds an additional costly conversion step 
delaunay(dim, npts, Vector{Float64(x))
```

In my applications, I work with a large number of points. Converting between data formats then quickly becomes computationally unfeasible, so it is crucial performance-wise to be able to not explicitly convert to `Vector{Float64}` before passing the data to `delaunay`.

I think this package would be more flexible if `delaunay` could accept any subtype of `AbstractVector{Float64}` as input data.

## Solution 

This PR solves the problem described above by having less strict type requirements (i.e. using `AbstractVector`/`AbstractArray` instead of `Vector`/`Array`). The current behaviour is not affected, but it is now possible to use `Base.ReinterpretArray` (and other similar types) as input.

## Documentation

I added an extra use case to the documentation, similar to the examples above, highlighting how reinterpreted static vectors can be used as input to `delaunay`.

## Other 

This PR also includes the GitHub Actions CI testing that I added in a separate PR. 