### PR TITLE
update Qhull_jll version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MiniQhull"
 uuid = "978d7f02-9e05-4691-894f-ae31a51d76ca"
 authors = ["Francesc Verdugo <fverdugo@cimne.upc.edu>", "Victor Sande <vsande@cimne.upc.edu>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CMake = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
@@ -10,7 +10,7 @@ Qhull_jll = "784f63db-0788-585a-bace-daefebcd302b"
 
 [compat]
 CMake = "1.2.0"
-Qhull_jll = "v2019.1.0, v2020.2.0"
+Qhull_jll = "8"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Qhull_jll is now using the semantic versions, rather than year-based versions: https://github.com/JuliaPackaging/Yggdrasil/pull/3662